### PR TITLE
Feature/organism metdata

### DIFF
--- a/public/cap/js/speciesbar.js
+++ b/public/cap/js/speciesbar.js
@@ -1,0 +1,69 @@
+// a d3.js script to draw a cell fraction bar for the repo summary
+
+// Define the div for the tooltip
+var div = d3.select("body").append("div")	
+    .attr("class", "tooltip")				
+    .style("opacity", 0);
+
+var data = fullInfo.Terms
+
+var svg = d3.select("#cellbar"),
+    svgSize=svg.node().getBoundingClientRect(),
+    margin = {top: 10, right: 1, bottom: 1, left: 1},
+    width = +svgSize.width - margin.left - margin.right,
+    height = +svgSize.height - margin.top - margin.bottom,
+    g = svg.append("g").attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+
+var y = d3.scaleBand()	
+    .rangeRound([0, height])	
+    .paddingInner(0.05)
+    .align(0.1);
+
+var x = d3.scaleLinear()	
+    .rangeRound([0, width]);	
+
+var keys = Object.keys(data) // terms
+var z = d3.scaleOrdinal().domain(keys).range(d3.schemeSet3)
+
+for (i = 0, t = 0; i < keys.length; i++) {
+    let v=data[keys[i]];
+    data[keys[i]]=[t,t+v,keys[i]];
+    t+=v;
+};
+data=Object.values(data) // transform object into an array
+
+x.domain([0,t])
+
+// draw the rects
+g.append("g")
+    .selectAll("rect")
+    .data(data)
+    .enter().append("rect")
+    .attr("x",function(d) { return x(d[0]) })
+    .attr("y",y(0))
+    .attr("fill",function(d) {  return z(d[2]) })
+    .attr("width",function(d) { return x(d[1])-x(d[0]) })
+    .attr("height",y.bandwidth(0))
+    .on("mouseover", function(d) {
+	div.transition()		
+            .duration(200)		
+            .style("opacity", .9);		
+        div.html(d[2])
+            .style("left", (d3.event.pageX ) + "px")		
+            .style("top", (d3.event.pageY -30) + "px");
+        d3.select(this).style("fill", function() {
+            return d3.rgb(d3.select(this).style("fill")).darker(0.5);
+        });
+    })
+    .on("mouseout", function(d) {
+	d3.select(this).style("fill", function() {
+            return d3.rgb(d3.select(this).style("fill")).brighter(0.5);
+        })
+        div.transition()		
+            .duration(500)		
+            .style("opacity", 0);	
+    })
+
+
+// bounding box
+g.append("g").append("rect").attr("x",x(0)).attr("stroke","black").attr("stroke-width",0.8).attr("width",x(data[data.length-1][1])).attr("height",y.bandwidth()).attr("fill","none")

--- a/public/cap/js/speciesbar.js
+++ b/public/cap/js/speciesbar.js
@@ -5,7 +5,7 @@ var div = d3.select("body").append("div")
     .attr("class", "tooltip")				
     .style("opacity", 0);
 
-var data = fullInfo.Terms
+var data = fullInfo.Species
 
 var svg = d3.select("#cellbar"),
     svgSize=svg.node().getBoundingClientRect(),
@@ -22,7 +22,7 @@ var y = d3.scaleBand()
 var x = d3.scaleLinear()	
     .rangeRound([0, width]);	
 
-var keys = Object.keys(data) // terms
+var keys = Object.keys(data) // species
 var z = d3.scaleOrdinal().domain(keys).range(d3.schemeSet3)
 
 for (i = 0, t = 0; i < keys.length; i++) {

--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -57,6 +57,19 @@ func linesBytesCount(s []byte) int {
 	return n
 }
 
+func removeDuplicateSpecies(intSlice []string) []string { 
+    keys := make(map[string]bool) 
+    list := make([]string, 0)
+  
+    for _, entry := range intSlice { 
+        if _, value := keys[entry]; !value { 
+            keys[entry] = true
+            list = append(list, entry) 
+        } 
+    } 
+    return list 
+} 
+
 // FIXME: There has to be a more efficient way of doing this
 func getReadmeFileFromPath(commit *git.Commit, treePath string) (*namedBlob, error) {
 	tree, err := commit.SubTree(treePath)
@@ -211,9 +224,17 @@ func renderDirectory(ctx *context.Context, treeLink string) {
 								for _,v := range str.Datasets {
 									tcells+=v
 								}
+								
+								total_species := make([]string, 0)
+								for k, v := range str.Species { 
+									total_species = append(total_species, str.Species[k])
+								}
+								total_species = removeDuplicateSpecies(total_species)
+
 								ctx.Data["NCells"]=tcells
 								ctx.Data["NDatasets"]=len(str.Datasets)
 								ctx.Data["NTerms"]=len(str.Terms)
+								ctx.Data["NSpecies"] = len(total_species)
 								ctx.Data["FullInfo"]=str;
 								
 								//fmt.Printf("%+v\n",ctx.Data)

--- a/templates/repo/cap_summary.tmpl
+++ b/templates/repo/cap_summary.tmpl
@@ -10,6 +10,9 @@
 			<div class="item">
 				<span class="ui active">{{svg "dot " 16}} <b>{{.NCells}} cells</b></span>
 			</div>
+			<div class="item">
+				<span class="ui active">{{svg "dot " 16}} <b>{{.NSpecies}} species</b></span>
+			</div>
 		{{if ge .NCells 0}}
 		        <div class="ui basic jump dropdown icon poping up" data-content="Download Normalized Annotations" data-variation="tiny inverted" data-position="top right" tabindex="0">
 				<i class="download icon"></i>

--- a/templates/repo/cap_summary.tmpl
+++ b/templates/repo/cap_summary.tmpl
@@ -28,6 +28,10 @@
 		   <script type="text/javascript">var fullInfo = {{.FullInfo}}</script>
                    <script src="https://d3js.org/d3.v5.min.js"></script>
 		   <script src="{{StaticUrlPrefix}}/cap/js/cellbar.js"></script>
+		   <svg id="speciesbar" height="30" width="100%" xmlns="http://www.w3.org/2000/svg"/>
+		   <script type="text/javascript">var fullInfo = {{.FullInfo}}</script>
+                   <script src="https://d3js.org/d3.v5.min.js"></script>
+		   <script src="{{StaticUrlPrefix}}/cap/js/speciesbar.js"></script>
                 {{end}}
 	</div>
 </div>


### PR DESCRIPTION
Sketch to include organism info as well. Haven't fully checked.

Work in tandem with https://github.com/kharchenkolab/cap-annparser/tree/feature/organism_metdata

This is possibly a bad idea, but including organisms seems reasonable enough. 

* The major short-coming with this idea is if users use multiple strings for the same organism, e.g. `"human", "homo sapiens", "Homo_sapiens". But the d3 bar should show them the error of their ways...